### PR TITLE
Fix NullPointerException for issuer without scheme in id token

### DIFF
--- a/library/java/net/openid/appauth/IdToken.java
+++ b/library/java/net/openid/appauth/IdToken.java
@@ -229,7 +229,8 @@ public class IdToken {
             // components.
             Uri issuerUri = Uri.parse(this.issuer);
 
-            if (!skipIssuerHttpsCheck && !issuerUri.getScheme().equals("https")) {
+            String issuerScheme = issuerUri.getScheme();
+            if (!skipIssuerHttpsCheck && (issuerScheme == null || !issuerScheme.equals("https"))) {
                 throw AuthorizationException.fromTemplate(GeneralErrors.ID_TOKEN_VALIDATION_ERROR,
                     new IdTokenException("Issuer must be an https URL"));
             }

--- a/library/javatests/net/openid/appauth/IdTokenTest.java
+++ b/library/javatests/net/openid/appauth/IdTokenTest.java
@@ -361,6 +361,34 @@ public class IdTokenTest {
         idToken.validate(tokenRequest, clock);
     }
 
+    @Test(expected = AuthorizationException.class)
+    public void testValidate_shouldFailOnIssuerMissingScheme()
+        throws AuthorizationException, JSONException, MissingArgumentException {
+        Long nowInSeconds = SystemClock.INSTANCE.getCurrentTimeMillis() / 1000;
+        Long tenMinutesInSeconds = (long) (10 * 60);
+        IdToken idToken = new IdToken(
+            "some.issuer",
+            TEST_SUBJECT,
+            Collections.singletonList(TEST_CLIENT_ID),
+            nowInSeconds + tenMinutesInSeconds,
+            nowInSeconds
+        );
+
+        String serviceDocJsonWithIssuerMissingHost = getDiscoveryDocJsonWithIssuer("some.issuer");
+        AuthorizationServiceDiscovery discoveryDoc = new AuthorizationServiceDiscovery(
+            new JSONObject(serviceDocJsonWithIssuerMissingHost));
+        AuthorizationServiceConfiguration serviceConfiguration =
+            new AuthorizationServiceConfiguration(discoveryDoc);
+        TokenRequest tokenRequest = new TokenRequest.Builder(serviceConfiguration, TEST_CLIENT_ID)
+            .setAuthorizationCode(TEST_AUTH_CODE)
+            .setCodeVerifier(TEST_CODE_VERIFIER)
+            .setGrantType(GrantTypeValues.AUTHORIZATION_CODE)
+            .setRedirectUri(TEST_APP_REDIRECT_URI)
+            .build();
+        Clock clock = SystemClock.INSTANCE;
+        idToken.validate(tokenRequest, clock);
+    }
+
     @Test
     public void testValidate_audienceMatch() throws AuthorizationException {
         Long nowInSeconds = SystemClock.INSTANCE.getCurrentTimeMillis() / 1000;


### PR DESCRIPTION
Uri.getScheme() may return null if no scheme is contained in the given string. This could cause a crash during id token validation when this was the case for the contained "iss" claim.

https://github.com/openid/AppAuth-Android/pull/841