### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,20 @@
 ---
 name: build
 
-on: [push, pull_request]
+on:
+  # Allows to run this workflow when a commit it pushed to the branch
+  push:
+    paths-ignore:
+      - "**/*.md"
+    branches:
+      - develop
+
+  # Allows to run this workflow when a Pull Request is made with the set target branch
+  pull_request:
+    paths-ignore:
+      - "**/*.md"
+    branches:
+      - develop
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,5 @@
 ---
-name: build
+name: Build Project
 
 on:
   # Allows to run this workflow when a commit it pushed to the branch

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,25 +8,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK 17
-        uses: actions/setup-java@v2
-        with:
-          java-version: '17'
-          distribution: 'temurin'
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-      - name: Cache Gradle packages
-        uses: actions/cache@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
         with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
+          java-version: "17"
+          distribution: "temurin"
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
 
       - name: Build
         run: ./gradlew check jacoco assemble
-
-      - name: Codecov
-        uses: codecov/codecov-action@v3

--- a/.github/workflows/jitpack-build.yml
+++ b/.github/workflows/jitpack-build.yml
@@ -24,7 +24,4 @@ jobs:
 
       - name: Trigger Jitpack Build
         run: |
-          curl -X POST https://jitpack.io/api/builds \
-          -d 'scm=github.com' \
-          -d 'repo=nisrulz/AppAuth-Android' \
-          -d 'branch=develop'
+          curl https://jitpack.io/api/builds/com.github.nisrulz/AppAuth-Android/develop-SNAPSHOT

--- a/.github/workflows/jitpack-build.yml
+++ b/.github/workflows/jitpack-build.yml
@@ -1,0 +1,20 @@
+name: Force Jitpack Build
+
+on:
+  push:
+    branches:
+      - develop
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Trigger Jitpack Build
+        run: |
+          curl -X POST https://jitpack.io/api/builds \
+          -d 'scm=github.com' \
+          -d 'repo=nisrulz/AppAuth-Android' \
+          -d 'branch=develop'

--- a/.github/workflows/jitpack-build.yml
+++ b/.github/workflows/jitpack-build.yml
@@ -1,7 +1,17 @@
 name: Force Jitpack Build
 
 on:
+  # Allows to run this workflow when a commit it pushed to the branch
   push:
+    paths-ignore:
+      - "**/*.md"
+    branches:
+      - develop
+
+  # Allows to run this workflow when a Pull Request is made with the set target branch
+  pull_request:
+    paths-ignore:
+      - "**/*.md"
     branches:
       - develop
 


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflows to improve the build and deployment processes by refining the triggers and updating the actions used.

Improvements to GitHub Actions workflows:

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L4-L32): Updated the workflow to trigger only on changes to the `develop` branch, excluding markdown files, and updated the actions used for checking out the repository, setting up Java, and setting up Gradle. Removed the caching of Gradle packages and the Codecov step.
* [`.github/workflows/jitpack-build.yml`](diffhunk://#diff-289f1a4931f5c2ae3df1b4d34624b33088957a02333465e9af32f38d021c32ffR1-R27): Added a new workflow to force a Jitpack build when changes are pushed to the `develop` branch or a pull request is made to the `develop` branch, excluding markdown files.